### PR TITLE
Override submit url and button text with constants

### DIFF
--- a/blueprint-extractor.php
+++ b/blueprint-extractor.php
@@ -334,6 +334,16 @@ class BlueprintExtractor {
 			$name .= ' V2';
 		}
 
+		$submit_url = 'https://blueprintlibrary.wordpress.com/';
+		if ( defined( 'PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_URL' ) ) {
+			$submit_url = PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_URL;
+		}
+
+		$submit_button_text = 'Submit the Blueprint to WordPress.com';
+		if ( defined( 'PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_BUTTON_TEXT' ) ) {
+			$submit_button_text = PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_BUTTON_TEXT;
+		}
+
 		?><div class="wrap">
 		<h1>Blueprint</h1>
 			<style>
@@ -378,7 +388,7 @@ class BlueprintExtractor {
 					color: #fff;
 				}
 			</style>
-			<form target="_blank" action="https://blueprintlibrary.wordpress.com/" method="post">
+			<form target="_blank" action="<?php echo esc_url( $submit_url ); ?>" method="post">
 			Name: <input type="text" id="blueprint-name" name="name" value="<?php echo esc_attr( $name ); ?>" class="regular-text" /><br>
 			Landing Page: <input type="text" id="landing-page" value="<?php echo esc_attr( $blueprint['landingPage'] ); ?>" onchange="updateBlueprint()" onkeyup="updateBlueprint()" /><br>
 
@@ -585,7 +595,9 @@ class BlueprintExtractor {
 			<br/>
 			<br/>
 			<button id="copy-blueprint" class="button">Copy the blueprint to clipboard</button>
-			<button class="button">Submit the blueprint to WordPress.com</button>
+			<button class="button" onclick="submitBlueprint()">
+				<?php echo esc_html( $submit_button_text ); ?>
+			</button>
 			<button id="clear-local-storage" class="button button-destructive" style="margin-left: 10em">Reset Previous Selections</button>
 			<br>
 			<br>

--- a/blueprint-extractor.php
+++ b/blueprint-extractor.php
@@ -599,7 +599,7 @@ class BlueprintExtractor {
 			<br/>
 			<br/>
 			<button id="copy-blueprint" class="button">Copy the blueprint to clipboard</button>
-			<button class="button" onclick="submitBlueprint()">
+			<button class="button">
 				<?php echo esc_html( $submit_button_text ); ?>
 			</button>
 			<button id="clear-local-storage" class="button button-destructive" style="margin-left: 10em">Reset Previous Selections</button>

--- a/blueprint-extractor.php
+++ b/blueprint-extractor.php
@@ -195,6 +195,10 @@ class BlueprintExtractor {
 		unset( $constants['DB_CHARSET'] );
 		unset( $constants['DB_COLLATE'] );
 
+		// Unset Blueprint Extractor constants.
+		unset( $constants['BLUEPRINT_EXTRACTOR_SUBMIT_URL'] );
+		unset( $constants['BLUEPRINT_EXTRACTOR_SUBMIT_BUTTON_TEXT'] );
+
 		return $constants;
 	}
 
@@ -335,13 +339,13 @@ class BlueprintExtractor {
 		}
 
 		$submit_url = 'https://blueprintlibrary.wordpress.com/';
-		if ( defined( 'PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_URL' ) ) {
-			$submit_url = PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_URL;
+		if ( defined( 'BLUEPRINT_EXTRACTOR_SUBMIT_URL' ) ) {
+			$submit_url = BLUEPRINT_EXTRACTOR_SUBMIT_URL;
 		}
 
 		$submit_button_text = 'Submit the Blueprint to WordPress.com';
-		if ( defined( 'PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_BUTTON_TEXT' ) ) {
-			$submit_button_text = PLAYGROUND_EXTRACTOR_BLUEPRINT_SUBMIT_BUTTON_TEXT;
+		if ( defined( 'BLUEPRINT_EXTRACTOR_SUBMIT_BUTTON_TEXT' ) ) {
+			$submit_button_text = BLUEPRINT_EXTRACTOR_SUBMIT_BUTTON_TEXT;
 		}
 
 		?><div class="wrap">


### PR DESCRIPTION
In some cases, apps may want to override the submit button and URL with their own. 
For example, the Blueprint Library wants to use a different URL for submissions if a Blueprint is being edited. 

To add support for customizing the submit button and URL, this PR adds support for overriding both values using constants.

The `BLUEPRINT_EXTRACTOR_SUBMIT_URL` and `BLUEPRINT_EXTRACTOR_SUBMIT_BUTTON_TEXT` constants won't be added to the extracted Blueprint, similarly to `DB` constants.

## Testing instructions

- Add this step to blueprint.json
```
        {
            "step": "defineWpConfigConsts",
            "consts": {
                "BLUEPRINT_EXTRACTOR_SUBMIT_URL": "https://blueprintlibrary.wordpress.com/?edit-blueprint=399",
                "BLUEPRINT_EXTRACTOR_SUBMIT_BUTTON_TEXT": "Update Blueprint on WordPress.com"
            }
        }
```
- Start a local site
- Go to the Blueprints admin page
- Confirm that the URL and button text match the constants
- Confirm that the constants aren't listed in the extracted Blueprint