### PR TITLE
Update the installTheme step and remove unused steps

### DIFF
--- a/blueprint-extractor.php
+++ b/blueprint-extractor.php
@@ -315,10 +315,6 @@ class BlueprintExtractor {
 				'php' => substr( phpversion(), 0, 3 ),
 				'wp'  => $wp_version,
 			),
-			'phpExtensionBundles' => array( 'kitchen-sink' ),
-			'features'            => array(
-				'networking' => true,
-			),
 			'login'               => true,
 			'steps'               => $steps,
 		);

--- a/blueprint-extractor.php
+++ b/blueprint-extractor.php
@@ -281,7 +281,7 @@ class BlueprintExtractor {
 		if ( ! in_array( $theme->get( 'TextDomain' ), $ignore ) && $this->check_theme_exists( $theme->get( 'TextDomain' ) ) && ! $ignore_theme ) {
 			$steps[] = array(
 				'step'         => 'installTheme',
-				'themeZipFile' => array(
+				'themeData' => array(
 					'resource' => 'wordpress.org/themes',
 					'slug'     => $theme->get( 'TextDomain' ),
 				),


### PR DESCRIPTION
Before this PR, the Blueprint Extractor produced invalid Blueprints. 
The theme step syntax uses the outdated `themeZipFile` key, and the Blueprint contains the deprecated `phpExtensionBundles` property. Also, networking is now enabled by default, so it's not needed anymore. 

## Testing instructions 

- Start the site
- Navigate to http://127.0.0.1:9400/wp-admin/admin.php?page=blueprint
- Click _Submit the Blueprint to WordPress.com_
- In the Blueprints Library, confirm that there are no warnings in the Blueprint editor